### PR TITLE
fix/installer: supporting installer on Ubuntu 20

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,13 @@
     dest: "{{ omsagent_tmp }}"
     mode: "750"
 
+- name: Correct python version selected
+  alternatives:
+    link: /usr/bin/python
+    name: python
+    path: "{{ discovered_interpreter_python }}"
+    priority: 0
+
 - name: ensure directory exist
   file:
     path: /etc/opt/microsoft/omsagent
@@ -32,9 +39,9 @@
 
 - name: run script (can take a couple of minutes)
   command: "{{ omsagent_tmp }}/onboard_agent.sh"
+  register: shell_res
   args:
-    creates: omsagent-{{ omsagent_version }}.universal.{{ omsagent_creates_pattern }}.sh
-    chdir: "{{ omsagent_tmp }}"
+    creates: /opt/omi/bin/omiserver
 
 - name: wait for omid to start from script
   pause:
@@ -47,3 +54,5 @@
     enabled: yes
   when:
     - omsagent_service_state | length
+
+- debug: msg="{{ omsagent_tmp }}/omsagent-{{ omsagent_version }}.universal.{{ omsagent_creates_pattern }}.sh"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,5 +54,3 @@
     enabled: yes
   when:
     - omsagent_service_state | length
-
-- debug: msg="{{ omsagent_tmp }}/omsagent-{{ omsagent_version }}.universal.{{ omsagent_creates_pattern }}.sh"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,12 +2,17 @@
 # vars file for omsagent
 
 _omsagent_requirements:
-  default:
+  Debian:
+    - linux-libc-dev
+    - python3-libtiff
+    - libpam-modules
+  RedHat:
     - glibc
-    - openssl
-    - curl
     - python-ctypes
     - pam
+  default:
+    - openssl
+    - curl
     - wget
     - which
 


### PR DESCRIPTION
---
name: fix/installer: supporting installer on Ubuntu 20
about: installer

---

**Describe the change**
Installer is broking in Debian-based OS for those reasons:
- wrong package names for that OS family
- missing alternatives to use the current python runtime
- installation is not idepotent because version checked is different for script have downloaded, so changing `creates` check to server binary path.

**Testing**
TODO
